### PR TITLE
Don't override nixpkgs of py2hwsw.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -51,7 +51,7 @@ in
 # If no root is provided, or there is a root but we want to force a rebuild
 if py2hwswRoot == "" || force_py2_build != 0 then
   # Use newly built nix package
-  import "${py2hwsw}/lib/python${builtins.substring 0 4 pkgs.python3.version}/site-packages/py2hwsw/lib/default.nix" { inherit pkgs; py2hwsw_pkg = py2hwsw; extra_pkgs = extra_pkgs; }
+  import "${py2hwsw}/lib/python${builtins.substring 0 4 pkgs.python3.version}/site-packages/py2hwsw/lib/default.nix" { py2hwsw_pkg = py2hwsw; extra_pkgs = extra_pkgs; }
 else
   # Use local
-  import "${py2hwswRoot}/py2hwsw/lib/default.nix" { inherit pkgs; py2hwsw_pkg = py2hwsw; extra_pkgs = extra_pkgs; }
+  import "${py2hwswRoot}/py2hwsw/lib/default.nix" { py2hwsw_pkg = py2hwsw; extra_pkgs = extra_pkgs; }


### PR DESCRIPTION
Same fix as in commit: https://github.com/IObundle/iob-soc/pull/1019/commits/ae789900996fd70d42601dc19e20ec64f93db575
This PR updates the default.nix file to match the new version from iob-soc's default.nix.